### PR TITLE
Handle invalid hashid decoding

### DIFF
--- a/packages/backend/tests/test_hashid.py
+++ b/packages/backend/tests/test_hashid.py
@@ -1,0 +1,15 @@
+import pytest
+from utils import hashid
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_encode_decode_roundtrip():
+    original = 123
+    encoded = hashid.encode(original)
+    assert hashid.decode(encoded) == original
+
+
+def test_decode_invalid_returns_none():
+    assert hashid.decode("invalid") is None

--- a/packages/backend/utils/hashid.py
+++ b/packages/backend/utils/hashid.py
@@ -9,4 +9,8 @@ def encode(val):
 
 
 def decode(val):
-    return hashids.decode(val)[0]
+    try:
+        decoded = hashids.decode(val)
+    except TypeError:
+        return None
+    return decoded[0] if decoded else None

--- a/packages/workers/utils/hashid.py
+++ b/packages/workers/utils/hashid.py
@@ -9,4 +9,8 @@ def encode(val):
 
 
 def decode(val):
-    return hashids.decode(val)[0]
+    try:
+        decoded = hashids.decode(val)
+    except TypeError:
+        return None
+    return decoded[0] if decoded else None


### PR DESCRIPTION
## Summary
- add safeguards to hashid.decode to avoid IndexError on invalid identifiers
- add regression test covering encode/decode behavior

## Testing
- `pdm run pytest -c tests/pytest.ini tests/test_hashid.py`


------
https://chatgpt.com/codex/tasks/task_e_68942698bc3c832594220b644ea64deb